### PR TITLE
Adding support for nonEmptyList and nonEmptyVector 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ objects to application specific types. The differentiating features of this libr
  - errors in the configuration are returned as values -- exceptions are never thrown
  - all errors present in the configuration are reported, not just the first error that is encountered
  - configuration parsers can be built manually or derived automatically from the structure of application specific types
- - limited dependencies -- only Typesafe Config and Shapeless
+ - limited dependencies -- only Typesafe Config, Shapeless, and Cats
 
 Example of usage:
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val core = project.in(file("core")).enablePlugins(SbtOsgi).
     libraryDependencies ++= Seq(
       "com.typesafe" % "config" % "1.3.0",
       "com.chuusai" %% "shapeless" % "2.3.2",
+      "org.typelevel" %% "cats-core" % "1.0.0-MF",
       "org.scalatest" %% "scalatest" % "3.0.1" % "test"
     ),
     buildOsgiBundle("com.ccadllc.cedi.config")

--- a/readme/src/main/tut/README.md
+++ b/readme/src/main/tut/README.md
@@ -14,7 +14,7 @@ objects to application specific types. The differentiating features of this libr
  - errors in the configuration are returned as values -- exceptions are never thrown
  - all errors present in the configuration are reported, not just the first error that is encountered
  - configuration parsers can be built manually or derived automatically from the structure of application specific types
- - limited dependencies -- only Typesafe Config and Shapeless
+ - limited dependencies -- only Typesafe Config, Shapeless, and Cats
 
 Example of usage:
 


### PR DESCRIPTION
Adding this support also invokes cats as a dependency, but provides more flexibility in the types of ConfigParsers, making them even safer for use.

Addresses issue https://github.com/ccadllc/cedi-config/issues/8